### PR TITLE
Fix file_dialog error

### DIFF
--- a/Brushshe/tools/file_dialog/file_dialog.py
+++ b/Brushshe/tools/file_dialog/file_dialog.py
@@ -71,6 +71,7 @@ class FileDialog(ctk.CTkToplevel):
 
         self._populate_file_list()
 
+        self.wait_visibility() 
         self.grab_set()
         self.wait_window()
 


### PR DESCRIPTION
If use open/save dialog get error: _tkinter.TclError: grab failed: window not viewable.

Need use wait_visibility() before grab_set().