### PR TITLE
Updated German Language Pack (de.json)

### DIFF
--- a/Brushshe/locales/de.json
+++ b/Brushshe/locales/de.json
@@ -125,5 +125,14 @@
   "Whole image": "Ganzes Bild",
   "Copied area": "Kopierter Bereich",
   "Change size": "Größe ändern",
-  "Crop": "Zuschneiden"
+  "Crop": "Zuschneiden",
+  "Refresh": "neu laden",
+	"Clear cache": "Cache leeren",
+	"Select": "Auswählen",
+	"Rectangle select": "Rechteck auswählen",
+	"Polygon select": "Polygon auswählen",
+	"Invert selected": "Ausgewählte Invertieren",
+	"Deselect all": "Ausgewählte Deselektieren",
+	"Open from URL": "Aus URL öffnen",
+	"Enter URL:": "URL Eingeben:"
 }


### PR DESCRIPTION
The German Language Pack now includes newly translated keys: 

- Refresh
- Clear cache
- Select
- Rectangle select
- Polygon select
- Invert selected
- Deselect all
- Open from URL
- Enter URL:

For consistency, I focussed my translations around the ones already done by the previous contributor.
Repeated words like "select" were translated to "Auswählen", so I took that over in my translation to. (You could also have translated "select" to just "wählen"