### PR TITLE
feat: add support for reading metadata from add-ons

### DIFF
--- a/Brushshe/gui/addon_manager.py
+++ b/Brushshe/gui/addon_manager.py
@@ -4,6 +4,7 @@
 
 import os
 import shutil
+import ast
 from tkinter import filedialog
 
 import customtkinter as ctk
@@ -40,9 +41,13 @@ class AddonManager:
             if f.endswith(".py"):
                 addons_number += 1
                 full_path = os.path.join(Constants.ADDONS_FOLDER, f)
+                metadata = self.get_addon_metadata(full_path)
                 AddonManagerItem(
                     self.installed_addons_frame,
-                    title=f,
+                    title=metadata.get("name", f),
+                    author=metadata.get("author"),
+                    version=metadata.get("version"),
+                    description=metadata.get("description"),
                     delete_button_command=lambda fp=full_path: self.uninstall_addon(fp),
                     run_button_command=lambda fp=full_path: self.run_addon(fp),
                 )
@@ -59,3 +64,24 @@ class AddonManager:
     def uninstall_addon(self, path: str):
         os.remove(path)
         self.load_installed_addons()
+
+    def get_addon_metadata(self, path: str) -> dict:
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                tree = ast.parse(f.read())
+            for node in tree.body:
+                if isinstance(node, ast.Assign):
+                    for target in node.targets:
+                        if isinstance(target, ast.Name) and target.id == "metadata":
+                            if isinstance(node.value, ast.Dict):
+                                metadata = {}
+                                for key, value in zip(node.value.keys, node.value.values):
+                                    if isinstance(key, (ast.Constant, ast.Str)):
+                                        k = key.value if isinstance(key, ast.Constant) else key.s
+                                        if isinstance(value, (ast.Constant, ast.Str, ast.Num)):
+                                            v = value.value if isinstance(value, ast.Constant) else (value.s if isinstance(value, ast.Str) else value.n)
+                                            metadata[k] = v
+                                return metadata
+        except Exception:
+            pass
+        return {}

--- a/Brushshe/ui/addon_manager_item.py
+++ b/Brushshe/ui/addon_manager_item.py
@@ -8,12 +8,31 @@ from utils.translator import _
 
 
 class AddonManagerItem(ctk.CTkFrame):
-    def __init__(self, master, title: str, delete_button_command=None, run_button_command=None, **kwargs):
+    def __init__(
+        self,
+        master,
+        title: str,
+        author: str = None,
+        version: str = None,
+        description: str = None,
+        delete_button_command=None,
+        run_button_command=None,
+        **kwargs,
+    ):
         super().__init__(master, **kwargs)
         super().pack(padx=10, pady=10, fill="x", expand=True)
 
-        self._label = ctk.CTkLabel(self, text=title)
+        display_text = title
+        if version:
+            display_text += f" v{version}"
+        if author:
+            display_text += f" {_('by')} {author}"
+
+        self._label = ctk.CTkLabel(self, text=display_text)
         self._label.pack(padx=10, pady=10, side="left")
+
+        if description:
+            Tooltip(self._label, description)
 
         self._delete_button = ctk.CTkButton(
             self, text="X", width=30, fg_color="red", hover_color="#cc0000", command=delete_button_command


### PR DESCRIPTION
Add support for reading and displaying a  dictionary from add-on files in the Add-on Manager.

Closes #74