### PR TITLE
fix: handle ImageTk failure and prevent KeyError in messagebox icons

### DIFF
--- a/Brushshe/ui/messagebox.py
+++ b/Brushshe/ui/messagebox.py
@@ -482,9 +482,13 @@ class Messagebox(ctk.CTkToplevel):
             else:
                 size = (self.height / 4, self.height / 4)
             self.ICONS[icon] = ctk.CTkImage(Image.open(image_path), size=size)
-            self.ICON_BITMAP[icon] = ImageTk.PhotoImage(file=image_path)
+            try:
+                self.ICON_BITMAP[icon] = ImageTk.PhotoImage(file=image_path)
+            except Exception:
+                self.ICON_BITMAP[icon] = None
         if not sys.platform.startswith("darwin"):
-            self.after(200, lambda: self.iconphoto(False, self.ICON_BITMAP[icon]))
+            if self.ICON_BITMAP.get(icon):
+                self.after(200, lambda: self.iconphoto(False, self.ICON_BITMAP.get(icon)))
         return self.ICONS[icon]
 
     def fade_in(self):


### PR DESCRIPTION
Fixes crash in messagebox icon handling.

- Wrapped ImageTk.PhotoImage in try/except to handle environments where Pillow/Tkinter integration may fail
- Replaced unsafe dictionary access with .get() to prevent KeyError
- Ensures the application does not crash when icons fail to load

Tested on develop branch and confirmed the issue is resolved.

Closes #92